### PR TITLE
Fix/falcon 2.0 incompatibility

### DIFF
--- a/falguard.py
+++ b/falguard.py
@@ -24,7 +24,7 @@ class _BravadoRequest(IncomingRequest):
         self.headers = falcon_request.headers
 
         # Non-reusable Falcon stream is replaced with reusable alternative
-        falcon_request.stream = io.BytesIO(falcon_request.stream.read())
+        falcon_request.stream = io.BytesIO(falcon_request.bounded_stream.read())
         data = falcon_request.stream.getvalue().decode()
         try:
             self.form = json.loads(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,6 @@ def make_test_app(validator):
     return api
 
 
-
 @pytest.fixture(params=VALIDATORS)
 def decorator_app(request):
     validator = request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,16 @@ class _ElementResource(object):
         assert test_id == 7
 
 
+def make_test_app(validator):
+    api = falcon.API(middleware=validator)
+    api.add_route('/tests', _CollectionResource())
+    api.add_route('/tests/{test_id}', _ElementResource())
+    # add entry point not in the specs
+    api.add_route('/backdoor', _CollectionResource())
+    return api
+
+
+
 @pytest.fixture(params=VALIDATORS)
 def decorator_app(request):
     validator = request.param
@@ -63,10 +73,10 @@ def decorator_app(request):
 
 @pytest.fixture(params=VALIDATORS)
 def middleware_app(request):
-    validator = request.param
-    api = falcon.API(middleware=validator)
-    api.add_route('/tests', _CollectionResource())
-    api.add_route('/tests/{test_id}', _ElementResource())
-    # add entry point not in the specs
-    api.add_route('/backdoor', _CollectionResource())
+    api = make_test_app(request.param)
     return webtest.TestApp(api)
+
+
+@pytest.fixture(params=VALIDATORS)
+def middleware_falcon_app(request):
+    return make_test_app(request.param)

--- a/tests/test_ok.py
+++ b/tests/test_ok.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 
+from falcon.testing.client import TestClient as Client
 import pytest
 
 Case = namedtuple('Case', ['method', 'url', 'data_or_params'])
@@ -42,3 +43,12 @@ def test_decorator_validation_ok(method, url, data_or_params, decorator_app):
 @pytest.mark.parametrize('method, url, data_or_params', CASES)
 def test_middleware_validation_ok(method, url, data_or_params, middleware_app):
     getattr(middleware_app, method)(url, data_or_params)
+
+
+@pytest.mark.parametrize('method, url, data_or_params', CASES)
+def test_middleware_falcon_test_client_ok(method, url, data_or_params, middleware_falcon_app):
+    client = Client(middleware_falcon_app)
+    if method == 'get':
+        client.simulate_get(url, params=data_or_params)
+    elif method == 'post_json':
+        client.simulate_post(url, json=data_or_params)


### PR DESCRIPTION
Among Falcon 2.0 backward incompatible changes, there is: 

* The :attr:`falcon.Request.stream` attribute is no longer wrapped in a bounded
  stream when Falcon detects that it is running on the wsgiref server. If you
  need to normalize stream semantics between wsgiref and a production WSGI
  server, :attr:`~.Request.bounded_stream` may be used instead.

That causes an exeption in `_BravadoRequest` when an application using Falguard is tested using Falcon's `TestClient` (which uses `wsgiref`).

This PR aims at fixing that.