### PR TITLE
Handle invalid type in array query parameter

### DIFF
--- a/falguard.py
+++ b/falguard.py
@@ -51,7 +51,7 @@ class _JsonApiErrorResponseFormatter(object):
 
     def _get_source(self, validation_error):
         # pylint: disable=no-self-use
-        path = '/'.join(validation_error.path)
+        path = '/'.join(map(str, validation_error.path))
         if path:
             return {'pointer': '/' + path}
         parameter = validation_error.schema.get('name')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ VALIDATORS = [
 
 class _CollectionResource(object):
 
-    def on_get(self, request, response, search):
+    def on_get(self, request, response, search, clients):
         # pylint: disable=unused-argument,no-self-use
         assert search == datetime.date(2016, 12, 20)
 

--- a/tests/specs/spec.json
+++ b/tests/specs/spec.json
@@ -15,6 +15,14 @@
                 },
                 "parameters": [
                     {
+                        "name": "clients",
+                        "in": "query",
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    {
                         "name": "search",
                         "in": "query",
                         "type": "string",

--- a/tests/specs/spec.yaml
+++ b/tests/specs/spec.yaml
@@ -15,6 +15,11 @@ paths:
           type: string
           format: date
           required: true
+        - name: clients
+          in: query
+          type: array
+          items:
+            type: integer
     post:
       description: POST
       responses:

--- a/tests/specs/spec.yml
+++ b/tests/specs/spec.yml
@@ -15,6 +15,11 @@ paths:
           type: string
           format: date
           required: true
+        - name: clients
+          in: query
+          type: array
+          items:
+            type: integer
     post:
       description: POST
       responses:

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -26,6 +26,14 @@ CASES = [
     Case(
         method='simulate_get',
         url='/tests',
+        params={'clients': [5, 'non-integer-string'], 'search': '2016-12-20'},
+        body=None,
+        detail="'non-integer-string' is not of type 'integer'",
+        source={'pointer': '/1'},
+    ),
+    Case(
+        method='simulate_get',
+        url='/tests',
         params={'search': 'non-date-format-string'},
         body=None,
         detail="'non-date-format-string' is not a 'date'",


### PR DESCRIPTION
This should fix #7
I'm not happy with the `pointer` location. For this test it should be `clients/1` but I did not manage to get the parameter name from the exception.